### PR TITLE
API: implement the "id" query parameter

### DIFF
--- a/api/impl.go
+++ b/api/impl.go
@@ -67,13 +67,21 @@ func (s *Server) PostQuote(w http.ResponseWriter, r *http.Request) {
 
 	var newQuote quote.Quotation
 	if err := json.NewDecoder(r.Body).Decode(&newQuote); err != nil {
+		log.Printf("json decode failed: %s", err)
 		w.WriteHeader(http.StatusBadRequest)
 		_, _ = w.Write([]byte("could not read request body"))
 		return
 	}
 
-	s.AddQuote(newQuote)
+	if err := s.AddQuote(newQuote); err != nil {
+		log.Printf("QuoteBook Add failed: %s", err)
+		w.WriteHeader(http.StatusInsufficientStorage)
+		_, _ = w.Write([]byte(err.Error()))
+		return
+	}
+
 	w.WriteHeader(http.StatusCreated)
+	log.Printf("Quote added:\n%q\n%q", newQuote.Quote, newQuote.Author)
 	_ = newQuote.WriteJSON(w)
 }
 

--- a/pkg/quote/quote.go
+++ b/pkg/quote/quote.go
@@ -43,15 +43,16 @@ func New() *QuoteBook {
 	return new(QuoteBook)
 }
 
-func (q *QuoteBook) RandomQuotation() Quotation {
+func (q *QuoteBook) RandomQuotation() (*Quotation, error) {
 	q.Lock()
 	defer q.Unlock()
 	if len(q.quoteList) == 0 {
-		return Quotation{}
+		return nil, fmt.Errorf("empty QuoteBook")
 	}
 
 	idx := rand.Intn(len(q.quoteList))
-	return q.quoteList[idx]
+	quote := q.quoteList[idx]
+	return &quote, nil
 }
 
 func (q *QuoteBook) FillExample() {
@@ -73,6 +74,19 @@ func (q *QuoteBook) AddQuote(quote Quotation) error {
 	}
 	q.quoteList = append(q.quoteList, quote)
 	return nil
+}
+
+func (q *QuoteBook) GetQuote(num int) (*Quotation, error) {
+	q.Lock()
+	defer q.Unlock()
+	if len(q.quoteList) == 0 {
+		return nil, fmt.Errorf("empty QuoteBook")
+	}
+	if num >= len(q.quoteList) {
+		return nil, fmt.Errorf("id %d out of bounds", num)
+	}
+	quote := q.quoteList[num]
+	return &quote, nil
 }
 
 func (q *Quotation) WriteHTML(w io.Writer) error {

--- a/pkg/quote/quote.go
+++ b/pkg/quote/quote.go
@@ -18,6 +18,7 @@ package quote
 
 import (
 	"encoding/json"
+	"fmt"
 	"html/template"
 	"io"
 	"math/rand"
@@ -29,6 +30,8 @@ type Quotation struct {
 	Quote  string
 	Author string
 }
+
+const maxQuotes = 20
 
 // QuoteBook is a collection of Quotations
 type QuoteBook struct {
@@ -62,10 +65,14 @@ func (q *QuoteBook) FillExample() {
 	}
 }
 
-func (q *QuoteBook) AddQuote(quote Quotation) {
+func (q *QuoteBook) AddQuote(quote Quotation) error {
 	q.Lock()
 	defer q.Unlock()
+	if len(q.quoteList) > maxQuotes {
+		return fmt.Errorf("QuoteBook is full")
+	}
 	q.quoteList = append(q.quoteList, quote)
+	return nil
 }
 
 func (q *Quotation) WriteHTML(w io.Writer) error {


### PR DESCRIPTION
Implement the "id" query parameter to retrieve a quotation deterministically.
While there also add an hard limit to the number of quotations that could be added via the POST API.